### PR TITLE
Improve Types/Errors and Refactor Account.telemetry()

### DIFF
--- a/src/enterprise/api/types.ts
+++ b/src/enterprise/api/types.ts
@@ -347,17 +347,19 @@ export namespace Starlink {
 
     export namespace Telemetry {
         export namespace APIResponse {
+            export type DataValue = Array<number | string> | boolean | number | null | string;
+
             export interface Data {
                 data: {
-                    values: any[][];
+                    values: DataValue[][];
                     columnNamesByDeviceType: { [key: string]: string[] };
                 };
                 metadata: {
                     enums: {
                         DeviceType: { [key: string]: string };
-                        AlertsByDeviceType: { [key: string]: { [key: number]: string } }
-                    }
-                }
+                        AlertsByDeviceType: { [key: string]: { [key: string]: string } };
+                    };
+                };
             }
         }
 

--- a/src/enterprise/models/account.ts
+++ b/src/enterprise/models/account.ts
@@ -127,10 +127,20 @@ export default class Account extends BaseAPI {
                 routerConfigJson: JSON.stringify(routerConfig)
             });
 
-        return new RouterConfig(this.client_id, this.client_secret, {
-            ...response.content,
-            routerConfig: JSON.parse(response.content.routerConfigJson)
-        });
+        const {
+            routerConfigJson,
+            ...content
+        } = response.content;
+        const _routerConfig = JSON.parse(routerConfigJson);
+
+        return new RouterConfig(
+            this.client_id,
+            this.client_secret,
+            {
+                ...content,
+                routerConfig: _routerConfig
+            }
+        );
     }
 
     /**
@@ -337,10 +347,20 @@ export default class Account extends BaseAPI {
         const response = await this.get<Starlink.Common.Content<Starlink.Management.APIResponse.RouterConfig>>(
             `/enterprise/v1/account/${this.accountNumber}/routers/configs/${configId}`);
 
-        return new RouterConfig(this.client_id, this.client_secret, {
-            ...response.content,
-            routerConfig: JSON.parse(response.content.routerConfigJson)
-        });
+        const {
+            routerConfigJson,
+            ...content
+        } = response.content;
+        const routerConfig = JSON.parse(routerConfigJson);
+
+        return new RouterConfig(
+            this.client_id,
+            this.client_secret,
+            {
+                ...content,
+                routerConfig
+            }
+        );
     }
 
     /**
@@ -373,14 +393,22 @@ export default class Account extends BaseAPI {
             response = await this.get(
                 `/enterprise/v1/account/${this.accountNumber}/routers/configs`, options);
 
-            return response.content.results.map(record =>
-                new RouterConfig(
+            return response.content.results.map(record => {
+                const {
+                    routerConfigJson,
+                    ...rest
+                } = record;
+                const routerConfig = JSON.parse(routerConfigJson);
+
+                return new RouterConfig(
                     this.client_id,
                     this.client_secret,
                     {
-                        ...record,
-                        routerConfig: JSON.parse(record.routerConfigJson)
-                    }));
+                        ...rest,
+                        routerConfig
+                    }
+                );
+            });
         } else {
             const results: RouterConfig[] = [];
             let page = 0;
@@ -391,15 +419,22 @@ export default class Account extends BaseAPI {
                         page: page++
                     });
 
-                results.push(...response.content.results.map(record =>
-                    new RouterConfig(
+                results.push(...response.content.results.map(record => {
+                    const {
+                        routerConfigJson,
+                        ...rest
+                    } = record;
+                    const routerConfig = JSON.parse(routerConfigJson);
+
+                    return new RouterConfig(
                         this.client_id,
                         this.client_secret,
                         {
-                            ...record,
-                            routerConfig: JSON.parse(record.routerConfigJson)
+                            ...rest,
+                            routerConfig
                         }
-                    )));
+                    );
+                }));
             } while (!response.content.isLastPage);
 
             if (results.length !== response.content.totalCount) {

--- a/src/enterprise/models/account.ts
+++ b/src/enterprise/models/account.ts
@@ -869,23 +869,21 @@ export default class Account extends BaseAPI {
             UserTerminal: [],
             UserTerminalDataUsage: []
         };
-        const column_keys: any = {};
-        const alert_keys: any = {};
 
-        for (const key in response.metadata.enums.DeviceType) {
+        for (const key of Object.keys(response.metadata.enums.DeviceType)) {
+            const alertKeys = response.metadata.enums.AlertsByDeviceType[key] || {};
+            const columnKeys = response.data.columnNamesByDeviceType[key] || [];
             const type = response.metadata.enums.DeviceType[key];
 
             results[type] = [];
-            column_keys[type] = response.data.columnNamesByDeviceType[key] || [];
-            alert_keys[type] = response.metadata.enums.AlertsByDeviceType[key] || [];
 
-            const values = response.data.values.filter(value => value[0] === key);
+            const values = response.data.values.filter(([value]) => value === key);
 
             for (const value of values) {
-                const record: any = {};
+                const record: Record<string, Starlink.Telemetry.APIResponse.DataValue> = {};
 
-                for (let i = 1; i < column_keys[type].length; i++) {
-                    const column = column_keys[type][i];
+                for (let i = 1; i < columnKeys.length; i++) {
+                    const column = columnKeys[i];
 
                     record[column] = value[i];
                 }
@@ -895,7 +893,7 @@ export default class Account extends BaseAPI {
                         const alerts: string[] = [];
 
                         for (const alert of record.ActiveAlerts) {
-                            alerts.push(alert_keys[type][alert.toString()]);
+                            alerts.push(alertKeys[alert.toString()] || alert.toString());
                         }
 
                         record.ActiveAlerts = alerts;

--- a/src/enterprise/models/router_config.ts
+++ b/src/enterprise/models/router_config.ts
@@ -27,8 +27,6 @@ export default class RouterConfig extends BaseAPI {
         private routerConfig: Starlink.Management.Response.RouterConfig
     ) {
         super(client_id, client_secret);
-
-        delete (this.routerConfig as any).routerConfigJson;
     }
 
     public get accountNumber (): string {
@@ -69,12 +67,16 @@ export default class RouterConfig extends BaseAPI {
                     routerConfigJson: JSON.stringify(this.config)
                 });
 
-            this.routerConfig = {
-                ...response.content,
-                routerConfig: JSON.parse(response.content.routerConfigJson)
-            };
+            const {
+                routerConfigJson,
+                ...content
+            } = response.content;
+            const routerConfig = JSON.parse(routerConfigJson);
 
-            delete (this.routerConfig as any).routerConfigJson;
+            this.routerConfig = {
+                ...content,
+                routerConfig
+            };
 
             return true;
         } catch {

--- a/src/local/dishy.ts
+++ b/src/local/dishy.ts
@@ -51,7 +51,7 @@ export default class Dishy extends GRPCApi {
         const response = await this.handle({ getHistory: {} });
 
         if (!response.dishGetHistory) {
-            throw new Error(`No diagnostics returned from ${this.host}:${this.port}`);
+            throw new Error(`No history returned from ${this.host}:${this.port}`);
         }
 
         return response.dishGetHistory;
@@ -66,7 +66,7 @@ export default class Dishy extends GRPCApi {
         const response = await this.handle({ getLocation: {} });
 
         if (!response.getLocation) {
-            throw new Error(`No diagnostics returned from ${this.host}:${this.port}`);
+            throw new Error(`No location returned from ${this.host}:${this.port}`);
         }
 
         return response.getLocation;
@@ -79,7 +79,7 @@ export default class Dishy extends GRPCApi {
         const response = await this.handle({ dishGetObstructionMap: {} });
 
         if (!response.dishGetObstructionMap) {
-            throw new Error(`No diagnostics returned from ${this.host}:${this.port}`);
+            throw new Error(`No obstruction map returned from ${this.host}:${this.port}`);
         }
 
         return response.dishGetObstructionMap;
@@ -92,7 +92,7 @@ export default class Dishy extends GRPCApi {
         const response = await this.handle({ getStatus: {} });
 
         if (!response.dishGetStatus) {
-            throw new Error(`No diagnostics returned from ${this.host}:${this.port}`);
+            throw new Error(`No status returned from ${this.host}:${this.port}`);
         }
 
         return response.dishGetStatus;


### PR DESCRIPTION
These changes include the following:
- Improve logic and types when creating new `RouterConfig` instances by using the spread operator to remove the `routerConfigJson` property that does not exist in the `Starlink.Management.Response.RouterConfig` type rather than including it in the `routerConfig` property/object and immediately deleting it.
- Modify error messages in several `Dishy` class methods to match the data requested from each method.
- Update the `Starlink.Telemetry.APIResponse.Data` types to:
  - Declare a new `DataValue` type to improve the typing for the `Starlink.Telemetry.APIResponse.Data.data.values` property.
  - Update the `Starlink.Telemetry.APIResponse.Data.metadata.enums.AlertsByDeviceType` to match the data returned from the Starlink API, which uses stringified numbers as keys instead of true numbers.
- Refactor the `Account.telemetry()` method to:
  - Convert the `for...in` loop to `for...of` to avoid iterating over potential prototype properties.
  - Remove the `alert_keys` and `column_keys` objects and instead use local variables within the `for...of` loop.
  - Default `alertKeys` (replacement for `alert_keys` mentioned above) to an object instead of an array to match the data structure returned from the Starlink API.
  - Improve the typing for `record` to match the assigned data using the `DataValue` type.
  - Add a default when pushing to `alerts` to prevent pushing `undefined` if `alert` does not exist as a property on `AlertsByDeviceType`.