### PR TITLE
Add missing props in OverageLine and ServicePlan from Starlink.Management.Components

### DIFF
--- a/src/enterprise/api/types.ts
+++ b/src/enterprise/api/types.ts
@@ -427,6 +427,7 @@ export namespace Starlink {
                 SignalQuality: number,
                 H3CellId: number,
                 SecondsUntilSwupdateRebootPossible: number,
+                RunningSoftwareVersion: string;
                 ActiveAlerts: string []
             }
         }

--- a/src/enterprise/api/types.ts
+++ b/src/enterprise/api/types.ts
@@ -54,8 +54,10 @@ export namespace Starlink {
                 pricePerGB: number;
                 usageLimitGB: number;
                 overageAmountGB: number;
+                consumedAmountGB: number;
                 overagePrice: number;
                 productId: string | null;
+                dataOverageType: number;
             }
 
             export interface BillingCycle<DateType extends string | Date = string> {
@@ -85,6 +87,13 @@ export namespace Starlink {
                 overageLines: OverageLine[] | null;
             }
 
+            export interface DataCategoryMapping {
+                [key: string]: any;
+                nonBillableGB: number;
+                priorityGB: number;
+                standardGB: number;
+            }
+
             export interface ServicePlan<DateType extends string | Date = string> {
                 isoCurrencyCode: string | null;
                 isMobilePlan: boolean;
@@ -98,6 +107,7 @@ export namespace Starlink {
                 overageLine: OverageLine;
                 productId: string | null;
                 usageLimitGB: number;
+                dataCategoryMapping: DataCategoryMapping | null;
             }
 
             export interface Address {


### PR DESCRIPTION
This change adds missing props from `Starlink.Management.Components.OverageLine` and `Starlink.Management.Components.ServicePlan`. These props are included in the [documentation](https://starlink.readme.io/reference/post_enterprise-v1-accounts-accountnumber-billing-cycles-query) as seen here:
![image](https://github.com/user-attachments/assets/6a52d2ed-bcd8-4b9a-96eb-0d5bd9d216d3)

Here is also a screenshot from a request made with Postman showing the same props:
![image](https://github.com/user-attachments/assets/46971bbe-45cf-4d74-bdf9-1498737db07a)

The props for the `dataCategoryMapping` object are not specified, so I included what I saw in the API response and made it extensible.