### PR TITLE
Improve Types for Router, Service Line, and User Terminal

### DIFF
--- a/src/enterprise/api/types.ts
+++ b/src/enterprise/api/types.ts
@@ -144,15 +144,15 @@ export namespace Starlink {
                 billingCycles: ServiceLineBillingCycle<DateType>[] | null;
             }
 
-            export interface Router {
+            export interface Router<DateType extends Date | string = string> {
                 /**
                  * Account Number this router is bonded to.
                  */
-                accountNumber: string;
+                accountNumber: string | null;
                 /**
                  * Router config this router is assigned to, or empty if no config assigned.
                  */
-                configId: string;
+                configId: string | null;
                 /**
                  * True if this router is known to be directly connected to a user terminal.
                  */
@@ -161,6 +161,11 @@ export namespace Starlink {
                  * Hardware version of the router: 'v1', 'v2', or 'v3'.
                  */
                 hardwareVersion: string;
+                /**
+                 * Last time the router bonded to a user terminal
+                 */
+                lastBonded: DateType | null;
+                nickname: string | null;
                 routerId: string;
                 /**
                  * User terminal Id this router is bonded to.
@@ -231,9 +236,14 @@ export namespace Starlink {
                 active: boolean;
                 dishSerialNumber: string;
                 kitSerialNumber: string;
+                nickname: string | null;
                 routers: Router[];
                 serviceLineNumber: string | null;
                 userTerminalId: string;
+            }
+
+            export interface AviationMetadata {
+                tailNumber: string | null;
             }
 
             export interface ServiceLine<DateType extends Date | string = string> {
@@ -246,6 +256,7 @@ export namespace Starlink {
                  * Example: 55ec6574-10d8-bd9c-1951-d4184f4ae467
                  */
                 addressReferenceId: string;
+                aviationMetadata: AviationMetadata | null;
                 /**
                  * Scheduled product change for next bill date
                  */

--- a/src/enterprise/models/router.ts
+++ b/src/enterprise/models/router.ts
@@ -74,11 +74,11 @@ export default class Router extends BaseAPI {
         return JSON.stringify(this.router);
     }
 
-    public get accountNumber (): string {
+    public get accountNumber (): string | null {
         return this.router.accountNumber;
     }
 
-    public get configId (): string {
+    public get configId (): string | null {
         return this.router.configId;
     }
 
@@ -88,6 +88,16 @@ export default class Router extends BaseAPI {
 
     public get hardwareVersion (): string {
         return this.router.hardwareVersion;
+    }
+
+    public get lastBonded (): Date | null {
+        return this.router.lastBonded !== null
+            ? new Date(this.router.lastBonded)
+            : this.router.lastBonded;
+    }
+
+    public get nickname (): string | null {
+        return this.router.nickname;
     }
 
     public get routerId (): string {

--- a/src/enterprise/models/service_line.ts
+++ b/src/enterprise/models/service_line.ts
@@ -283,6 +283,10 @@ export default class ServiceLine extends BaseAPI {
         return this.serviceLine.addressReferenceId;
     }
 
+    public get aviationMetadata (): Starlink.Management.Components.AviationMetadata | null {
+        return this.serviceLine.aviationMetadata;
+    }
+
     public get delayedProductId (): string | null {
         return this.serviceLine.delayedProductId;
     }

--- a/src/enterprise/models/user_terminal.ts
+++ b/src/enterprise/models/user_terminal.ts
@@ -105,6 +105,10 @@ export default class UserTerminal extends BaseAPI {
         return this.userTerminal.kitSerialNumber;
     }
 
+    public get nickname (): string | null {
+        return this.userTerminal.nickname;
+    }
+
     public get routers (): Router[] {
         return this.userTerminal.routers.map(router => new Router(
             this.client_id,


### PR DESCRIPTION
This change makes the following changes:
- Adds missing props for the `Router`, `ServiceLine`, and `UserTerminal` types that live under `Starlink.Management.Components`
- Updates the type on two props from `Starlink.Management.Components.Router` that can be null
- Adds/Updates class getter methods for these new/updated props in the `Router`, `ServiceLine`, and `UserTerminal` classes in `src/enterprise/models`

`Router` [documentation](https://starlink.readme.io/reference/get_enterprise-v1-account-accountnumber-routers-routerid) and screenshots:
![image](https://github.com/user-attachments/assets/b4db8a73-1d78-441f-9c6d-c5f9c2d4b82b)
![image](https://github.com/user-attachments/assets/33cd3deb-49f2-425b-a988-a57e782fffb3)


`ServiceLine` [documentation](https://starlink.readme.io/reference/get_enterprise-v1-account-accountnumber-service-lines-servicelinenumber) and screenshots:
![image](https://github.com/user-attachments/assets/c551b375-7cbe-4030-a5ca-a6083ba3d718)
![image](https://github.com/user-attachments/assets/96ff33a5-2a06-4cd9-a6af-e8e878376d5d)

`UserTerminal` screenshot:
![image](https://github.com/user-attachments/assets/f4e9f34f-ddf1-4922-9f75-068668d4cd3b)
